### PR TITLE
Add basic security headers

### DIFF
--- a/cmd/api/mw/mw.go
+++ b/cmd/api/mw/mw.go
@@ -10,3 +10,20 @@ func Add(r *gin.Engine, h ...gin.HandlerFunc) {
 		r.Use(v)
 	}
 }
+
+// SecureHeaders adds general security headers for basic security measures
+func SecureHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Protects from MimeType Sniffing
+		c.Header("X-Content-Type-Options", "nosniff")
+		// Prevents browser from prefetching DNS
+		c.Header("X-DNS-Prefetch-Control", "off")
+		// Denies website content to be served in an iframe
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("Strict-Transport-Security", "max-age=5184000; includeSubDomains")
+		// Prevents Internet Explorer from executing downloads in site's context
+		c.Header("X-Download-Options", "noopen")
+		// Minimal XSS protection
+		c.Header("X-XSS-Protection", "1; mode=block")
+	}
+}

--- a/cmd/api/mw/mw_test.go
+++ b/cmd/api/mw/mw_test.go
@@ -1,0 +1,34 @@
+package mw_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ribice/gorsk/cmd/api/mw"
+)
+
+func TestAdd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	mw.Add(r, gin.Logger())
+}
+
+func TestSecureHeaders(t *testing.T) {
+	ts := httptest.NewServer(ginHandler(mw.SecureHeaders()))
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/hello")
+	if err != nil {
+		t.Fatal("Did not expect http.Get to fail")
+	}
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "off", resp.Header.Get("X-DNS-Prefetch-Control"))
+	assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"))
+	assert.Equal(t, "max-age=5184000; includeSubDomains", resp.Header.Get("Strict-Transport-Security"))
+	assert.Equal(t, "noopen", resp.Header.Get("X-Download-Options"))
+	assert.Equal(t, "1; mode=block", resp.Header.Get("X-XSS-Protection"))
+
+}

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -56,7 +56,7 @@ import (
 func main() {
 
 	r := gin.Default()
-	mw.Add(r, cors.Default())
+	mw.Add(r, cors.Default(), mw.SecureHeaders())
 
 	cfg, err := config.Load("dev")
 	checkErr(err)


### PR DESCRIPTION
Partially improves #6. Since I'm pretty unfamiliar with these, all of them where added from [THIS](https://github.com/danielkov/gin-helmet) repo (the default ones)

Should look into [THIS](https://github.com/unrolled/secure) before resolving #6.
