### PR TITLE
Add yaml config ENV variable parsing and Organize migration setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+APP_CFG_ENVIRONMENT_NAME=dev
+APP_CFG_DB_PSN=postgres://postgres:postgres@localhost:5432/gorsk?sslmode=disable

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 profile.out
 coverage.txt
 cmd/api/config/files/config.dev.yaml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,66 +2,51 @@
 
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:5fe3f6ede1c208a2efd3b78fe4df0306aa9624edd39476143d14f0326e5a8d29"
   name = "github.com/facebookgo/clock"
   packages = ["."]
-  pruneopts = "UT"
   revision = "600d898af40aa09a7a93ecb9265d87b0504b6f03"
 
 [[projects]]
   branch = "master"
-  digest = "1:1f21d86648746b776eae0dff77e4cafa2d9ccec0f0f1248c48306231ee800674"
   name = "github.com/facebookgo/grace"
   packages = [
     "gracehttp",
-    "gracenet",
+    "gracenet"
   ]
-  pruneopts = "UT"
   revision = "75cf19382434e82df4dd84953f566b8ad23d6e9e"
 
 [[projects]]
   branch = "master"
-  digest = "1:17cb421603403a24edb0c7eeb382295dd31c72ab9ccf31cf7f0a37971f00aaa7"
   name = "github.com/facebookgo/httpdown"
   packages = ["."]
-  pruneopts = "UT"
   revision = "5979d39b15c26299dc282711b0d65b113daccea6"
 
 [[projects]]
   branch = "master"
-  digest = "1:02c7a4e944d94d6b80f51517158d10633b10775f528a3b7bdfc658d6f92415bd"
   name = "github.com/facebookgo/stats"
   packages = ["."]
-  pruneopts = "UT"
   revision = "1b76add642e42c6ffba7211ad7b3939ce654526e"
 
 [[projects]]
   branch = "master"
-  digest = "1:ca0831a9c3eefdd659de2a1f02d0ee08f3630a11b5d5c098cc8aef4b52ff20fd"
   name = "github.com/fortytw2/dockertest"
   packages = ["."]
-  pruneopts = "UT"
   revision = "a73397bdeff4b713648d4b2e7fc655eb9a85fb6b"
 
 [[projects]]
-  digest = "1:5b14f08247db438a2d11b77aff373b6536028673e38eab87fb5062e07b3b7487"
   name = "github.com/go-pg/pg"
   packages = [
     ".",
@@ -69,187 +54,144 @@
     "internal/parser",
     "internal/pool",
     "orm",
-    "types",
+    "types"
   ]
-  pruneopts = "UT"
   revision = "c0368cd6ee62269f0a5c3d6c9c02c6d192760bc6"
   version = "v6.14.3"
 
 [[projects]]
-  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
   name = "github.com/go-playground/locales"
   packages = [
     ".",
-    "currency",
+    "currency"
   ]
-  pruneopts = "UT"
   revision = "f63010822830b6fe52288ee52d5a1151088ce039"
   version = "v0.12.1"
 
 [[projects]]
-  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
   name = "github.com/go-playground/universal-translator"
   packages = ["."]
-  pruneopts = "UT"
   revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
   version = "v0.16.0"
 
 [[projects]]
-  digest = "1:a351fd4cb95e313ecb345a521f276e7a00913d1f2e84c61543bc4fa1785ba7f3"
   name = "github.com/go-playground/validator"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ab2a8a99087e827c9af87ed6777ba897348fb178"
   version = "v9.20.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:fd97437fbb6b7dce04132cf06775bd258cce305c44add58eb55ca86c6c325160"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
-  pruneopts = "UT"
   revision = "04140366298a54a039076d798123ffa108fff46c"
 
 [[projects]]
-  digest = "1:87f801436ec4799e0e043ab348ff9f3e95b1b3761138158f0950ac67695cc272"
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  revision = "a79fa1e548e2c689c241d10173efd51e5d689d5b"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/labstack/echo"
   packages = [
     ".",
-    "middleware",
+    "middleware"
   ]
-  pruneopts = "UT"
   revision = "6d227dfea4d2e52cb76856120b3c17f758139b4e"
   version = "3.3.5"
 
 [[projects]]
-  digest = "1:568171fc14a3d819b112c3e219d351ea7b05e8dad7935c4168c6b3373244a686"
   name = "github.com/labstack/gommon"
   packages = [
     "bytes",
     "color",
     "log",
-    "random",
+    "random"
   ]
-  pruneopts = "UT"
   revision = "d6898124de917583f5ff5592ef931d1dfe0ddc05"
   version = "0.2.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:37ce7d7d80531b227023331002c0d42b4b4b291a96798c82a049d03a54ba79e4"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid",
+    "oid"
   ]
-  pruneopts = "UT"
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
-  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  pruneopts = "UT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:757b110984b77e820e01c60d3ac03a376a0fdb05c990dd9d6bd4f9ba0d606261"
   name = "github.com/rs/xid"
   packages = ["."]
-  pruneopts = "UT"
   revision = "2c7e97ce663ff82c49656bca3048df0fdd83c5f9"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
   name = "github.com/valyala/bytebufferpool"
   packages = ["."]
-  pruneopts = "UT"
   revision = "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7"
 
 [[projects]]
   branch = "master"
-  digest = "1:268b8bce0064e8c057d7b913605459f9a26dcab864c0886a56d196540fbf003f"
   name = "github.com/valyala/fasttemplate"
   packages = ["."]
-  pruneopts = "UT"
   revision = "dcecefd839c4193db0d35b88ec65b4c12d360ab0"
 
 [[projects]]
   branch = "master"
-  digest = "1:93f36793477e25b53507074bce6282e96efe7028b9adc8492c52bdb72f192328"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
     "acme/autocert",
     "bcrypt",
-    "blowfish",
+    "blowfish"
   ]
-  pruneopts = "UT"
   revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
-  digest = "1:8742e6e73627b2877c3f723bc1823d5667ec59011242480309dc90fa862512aa"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "UT"
   revision = "bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/dgrijalva/jwt-go",
-    "github.com/facebookgo/grace/gracehttp",
-    "github.com/fortytw2/dockertest",
-    "github.com/go-pg/pg",
-    "github.com/go-pg/pg/orm",
-    "github.com/go-playground/validator",
-    "github.com/labstack/echo",
-    "github.com/labstack/echo/middleware",
-    "github.com/lib/pq",
-    "github.com/rs/xid",
-    "github.com/stretchr/testify/assert",
-    "golang.org/x/crypto/bcrypt",
-    "gopkg.in/yaml.v2",
-  ]
+  inputs-digest = "91be9f08c5bbd139a3cccb8d9239673989bd703c5709eed1af4923b01e534176"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,9 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[constraint]]
+  branch = "master"
+  name = "github.com/joho/dotenv"
 
 [[constraint]]
   name = "github.com/dgrijalva/jwt-go"

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+
 	"path/filepath"
 	"runtime"
 
@@ -19,6 +21,10 @@ func Load(env string) (*Configuration, error) {
 		return nil, fmt.Errorf("error reading config file, %s", err)
 	}
 	var cfg = new(Configuration)
+
+	// Expands ENV vars that are in the ${var} format in the yaml file
+	bytes = []byte(os.ExpandEnv(string(bytes)))
+
 	if err := yaml.Unmarshal(bytes, cfg); err != nil {
 		return nil, fmt.Errorf("unable to decode into struct, %v", err)
 	}

--- a/cmd/api/config/files/config.dev.yaml
+++ b/cmd/api/config/files/config.dev.yaml
@@ -2,10 +2,10 @@ db:
   log: true
   timeout: 5 # Query timeout in seconds
   createschema: false
-  psn: postgres://biadpozi:3_Czbl7jSjkUEWk--VP8QXMke-mFnczq@horton.elephantsql.com:5432/biadpozi
+  psn: ${APP_CFG_DB_PSN}
 
 server:
-  port: ":8080"
+  port: ':8080'
   debug: true
   readtimeout: 10 # Request read timeout in minutes
   writetimeout: 5 # Response write timeout in minutes

--- a/cmd/api/config/files/config.example.yaml
+++ b/cmd/api/config/files/config.example.yaml
@@ -1,0 +1,16 @@
+db:
+  log: ${APP_CFG_DB_LOG} # Logging for db. true|false
+  timeout: ${APP_CFG_DB_TIMEOUT} # Query timeout in seconds
+  createschema: ${APP_CFG_DB_CREATESCHEMA} # Allow pg to create schema. true|false
+  psn: ${APP_CFG_DB_PSN}
+
+server:
+  port: ${APP_CFG_SERVER_PORT} # Port in a string form i.e: ':8080'
+  debug: ${APP_CFG_SERVER_DEBUG} # Remove for production
+  readtimeout: ${APP_CFG_SERVER_READTIMEOUT} # Request read timeout in minutes
+  writetimeout: ${APP_CFG_SERVER_WRITETIMEOUT} # Response write timeout in minutes
+
+jwt:
+  realm: ${APP_CFG_JWT_REALM} # Change this value, i.e: jwtrealm]
+  duration: ${APP_CFG_JWT_DURATION} # Duration in minutes
+  signingalgorithm: ${APP_CFG_JWT_SIGNINGALGORITHM} # For example, i.e: HS256

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -32,6 +32,9 @@
 package main
 
 import (
+	"os"
+
+	"github.com/joho/godotenv"
 	"github.com/labstack/echo"
 	"github.com/ribice/gorsk/internal/platform/postgres"
 
@@ -47,9 +50,16 @@ import (
 	"github.com/ribice/gorsk/internal/user"
 )
 
-func main() {
+const (
+	appEnvName = "APP_CFG_ENVIRONMENT_NAME"
+)
 
-	cfg, err := config.Load("dev")
+func main() {
+	err := godotenv.Load()
+	checkErr(err)
+
+	env := os.Getenv(appEnvName)
+	cfg, err := config.Load(env)
 	checkErr(err)
 
 	e := server.New()

--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-pg/pg/orm"
 
+	"github.com/ribice/gorsk/cmd/api/config"
 	"github.com/ribice/gorsk/internal"
 
 	"github.com/go-pg/pg"
@@ -14,6 +15,9 @@ import (
 )
 
 func main() {
+	cfg, err := config.Load("dev")
+	checkErr(err)
+
 	dbInsert := `INSERT INTO public.companies VALUES (1, now(), now(), NULL, 'admin_company', true);
 	INSERT INTO public.locations VALUES (1, now(), now(), NULL, 'admin_location', true, 'admin_address', 1);
 	INSERT INTO public.roles VALUES (1, 1, 'SUPER_ADMIN');
@@ -21,7 +25,7 @@ func main() {
 	INSERT INTO public.roles VALUES (3, 3, 'COMPANY_ADMIN');
 	INSERT INTO public.roles VALUES (4, 4, 'LOCATION_ADMIN');
 	INSERT INTO public.roles VALUES (5, 5, 'USER');`
-	var psn = ``
+	var psn = cfg.DB.PSN
 	queries := strings.Split(dbInsert, ";")
 
 	u, err := pg.ParseURL(psn)

--- a/cmd/migration/queries/0_db.go
+++ b/cmd/migration/queries/0_db.go
@@ -1,0 +1,7 @@
+package queries
+
+// DBSetupQueries queries to create/initialize/enable any extension or schema in the database
+func DBSetupQueries() (queries []string) {
+	queries = append(queries, `CREATE EXTENSION "uuid-ossp";`)
+	return queries
+}

--- a/cmd/migration/queries/1_company.go
+++ b/cmd/migration/queries/1_company.go
@@ -1,0 +1,7 @@
+package queries
+
+// CompanyQueries queries to initialize Company table
+func CompanyQueries() (queries []string) {
+	queries = append(queries, "INSERT INTO public.companies VALUES (1, now(), now(), NULL, 'admin_company', true);")
+	return queries
+}

--- a/cmd/migration/queries/2_location.go
+++ b/cmd/migration/queries/2_location.go
@@ -1,0 +1,7 @@
+package queries
+
+// LocationQueries queries to initialize Location table
+func LocationQueries() (queries []string) {
+	queries = append(queries, "INSERT INTO public.locations VALUES (1, now(), now(), NULL, 'admin_location', true, 'admin_address', 1);")
+	return queries
+}

--- a/cmd/migration/queries/3_role.go
+++ b/cmd/migration/queries/3_role.go
@@ -1,0 +1,11 @@
+package queries
+
+// RoleQueries queries to initialize Role table
+func RoleQueries() (queries []string) {
+	queries = append(queries, "INSERT INTO public.roles VALUES (1, 1, 'SUPER_ADMIN');")
+	queries = append(queries, "INSERT INTO public.roles VALUES (2, 2, 'ADMIN');")
+	queries = append(queries, "INSERT INTO public.roles VALUES (3, 3, 'COMPANY_ADMIN');")
+	queries = append(queries, "INSERT INTO public.roles VALUES (4, 4, 'LOCATION_ADMIN');")
+	queries = append(queries, "INSERT INTO public.roles VALUES (5, 5, 'USER');")
+	return queries
+}

--- a/cmd/migration/queries/4_user.go
+++ b/cmd/migration/queries/4_user.go
@@ -1,0 +1,14 @@
+package queries
+
+import (
+	"fmt"
+
+	"github.com/ribice/gorsk/internal/auth"
+)
+
+// UserQueries queries to initialize User table
+func UserQueries() (queries []string) {
+	userInsert := "INSERT INTO public.users VALUES (1, now(),now(), NULL, 'Admin', 'Admin', 'admin', '%s', 'johndoe@mail.com', NULL, NULL, NULL, NULL, true, 1, 1, 1);"
+	queries = append(queries, fmt.Sprintf(userInsert, auth.HashPassword("admin")))
+	return queries
+}

--- a/vendor/github.com/joho/godotenv/.gitignore
+++ b/vendor/github.com/joho/godotenv/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/vendor/github.com/joho/godotenv/.travis.yml
+++ b/vendor/github.com/joho/godotenv/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.8
+
+os:
+  - linux
+  - osx

--- a/vendor/github.com/joho/godotenv/LICENCE
+++ b/vendor/github.com/joho/godotenv/LICENCE
@@ -1,0 +1,23 @@
+Copyright (c) 2013 John Barton
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/joho/godotenv/README.md
+++ b/vendor/github.com/joho/godotenv/README.md
@@ -1,0 +1,163 @@
+# GoDotEnv [![Build Status](https://travis-ci.org/joho/godotenv.svg?branch=master)](https://travis-ci.org/joho/godotenv) [![Build status](https://ci.appveyor.com/api/projects/status/9v40vnfvvgde64u4?svg=true)](https://ci.appveyor.com/project/joho/godotenv) [![Go Report Card](https://goreportcard.com/badge/github.com/joho/godotenv)](https://goreportcard.com/report/github.com/joho/godotenv)
+
+A Go (golang) port of the Ruby dotenv project (which loads env vars from a .env file)
+
+From the original Library:
+
+> Storing configuration in the environment is one of the tenets of a twelve-factor app. Anything that is likely to change between deployment environments–such as resource handles for databases or credentials for external services–should be extracted from the code into environment variables.
+>
+> But it is not always practical to set environment variables on development machines or continuous integration servers where multiple projects are run. Dotenv load variables from a .env file into ENV when the environment is bootstrapped.
+
+It can be used as a library (for loading in env for your own daemons etc) or as a bin command.
+
+There is test coverage and CI for both linuxish and windows environments, but I make no guarantees about the bin version working on windows.
+
+## Installation
+
+As a library
+
+```shell
+go get github.com/joho/godotenv
+```
+
+or if you want to use it as a bin command
+```shell
+go get github.com/joho/godotenv/cmd/godotenv
+```
+
+## Usage
+
+Add your application configuration to your `.env` file in the root of your project:
+
+```shell
+S3_BUCKET=YOURS3BUCKET
+SECRET_KEY=YOURSECRETKEYGOESHERE
+```
+
+Then in your Go app you can do something like
+
+```go
+package main
+
+import (
+    "github.com/joho/godotenv"
+    "log"
+    "os"
+)
+
+func main() {
+  err := godotenv.Load()
+  if err != nil {
+    log.Fatal("Error loading .env file")
+  }
+
+  s3Bucket := os.Getenv("S3_BUCKET")
+  secretKey := os.Getenv("SECRET_KEY")
+
+  // now do something with s3 or whatever
+}
+```
+
+If you're even lazier than that, you can just take advantage of the autoload package which will read in `.env` on import
+
+```go
+import _ "github.com/joho/godotenv/autoload"
+```
+
+While `.env` in the project root is the default, you don't have to be constrained, both examples below are 100% legit
+
+```go
+_ = godotenv.Load("somerandomfile")
+_ = godotenv.Load("filenumberone.env", "filenumbertwo.env")
+```
+
+If you want to be really fancy with your env file you can do comments and exports (below is a valid env file)
+
+```shell
+# I am a comment and that is OK
+SOME_VAR=someval
+FOO=BAR # comments at line end are OK too
+export BAR=BAZ
+```
+
+Or finally you can do YAML(ish) style
+
+```yaml
+FOO: bar
+BAR: baz
+```
+
+as a final aside, if you don't want godotenv munging your env you can just get a map back instead
+
+```go
+var myEnv map[string]string
+myEnv, err := godotenv.Read()
+
+s3Bucket := myEnv["S3_BUCKET"]
+```
+
+... or from an `io.Reader` instead of a local file
+
+```go
+reader := getRemoteFile()
+myEnv, err := godotenv.Parse(reader)
+```
+
+... or from a `string` if you so desire
+
+```go
+content := getRemoteFileContent()
+myEnv, err := godotenv.Unmarshal(content)
+```
+
+### Command Mode
+
+Assuming you've installed the command as above and you've got `$GOPATH/bin` in your `$PATH`
+
+```
+godotenv -f /some/path/to/.env some_command with some args
+```
+
+If you don't specify `-f` it will fall back on the default of loading `.env` in `PWD`
+
+### Writing Env Files
+
+Godotenv can also write a map representing the environment to a correctly-formatted and escaped file
+
+```go
+env, err := godotenv.Unmarshal("KEY=value")
+err := godotenv.Write(env, "./.env")
+```
+
+... or to a string
+
+```go
+env, err := godotenv.Unmarshal("KEY=value")
+content, err := godotenv.Marshal(env)
+```
+
+## Contributing
+
+Contributions are most welcome! The parser itself is pretty stupidly naive and I wouldn't be surprised if it breaks with edge cases.
+
+*code changes without tests will not be accepted*
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Releases
+
+Releases should follow [Semver](http://semver.org/) though the first couple of releases are `v1` and `v1.1`.
+
+Use [annotated tags for all releases](https://github.com/joho/godotenv/issues/30). Example `git tag -a v1.2.1`
+
+## CI
+
+Linux: [![Build Status](https://travis-ci.org/joho/godotenv.svg?branch=master)](https://travis-ci.org/joho/godotenv) Windows: [![Build status](https://ci.appveyor.com/api/projects/status/9v40vnfvvgde64u4)](https://ci.appveyor.com/project/joho/godotenv)
+
+## Who?
+
+The original library [dotenv](https://github.com/bkeepers/dotenv) was written by [Brandon Keepers](http://opensoul.org/), and this port was done by [John Barton](http://whoisjohnbarton.com) based off the tests/fixtures in the original library.

--- a/vendor/github.com/joho/godotenv/godotenv.go
+++ b/vendor/github.com/joho/godotenv/godotenv.go
@@ -1,0 +1,314 @@
+// Package godotenv is a go port of the ruby dotenv library (https://github.com/bkeepers/dotenv)
+//
+// Examples/readme can be found on the github page at https://github.com/joho/godotenv
+//
+// The TL;DR is that you make a .env file that looks something like
+//
+// 		SOME_ENV_VAR=somevalue
+//
+// and then in your go code you can call
+//
+// 		godotenv.Load()
+//
+// and all the env vars declared in .env will be available through os.Getenv("SOME_ENV_VAR")
+package godotenv
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
+
+// Load will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Load without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Load("fileone", "filetwo")
+//
+// It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults
+func Load(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, false)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Overload will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Overload without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Overload("fileone", "filetwo")
+//
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefilly set all vars.
+func Overload(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, true)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Read all env (with same file loading semantics as Load) but return values as
+// a map rather than automatically writing values into env
+func Read(filenames ...string) (envMap map[string]string, err error) {
+	filenames = filenamesOrDefault(filenames)
+	envMap = make(map[string]string)
+
+	for _, filename := range filenames {
+		individualEnvMap, individualErr := readFile(filename)
+
+		if individualErr != nil {
+			err = individualErr
+			return // return early on a spazout
+		}
+
+		for key, value := range individualEnvMap {
+			envMap[key] = value
+		}
+	}
+
+	return
+}
+
+// Parse reads an env file from io.Reader, returning a map of keys and values.
+func Parse(r io.Reader) (envMap map[string]string, err error) {
+	envMap = make(map[string]string)
+
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err = scanner.Err(); err != nil {
+		return
+	}
+
+	for _, fullLine := range lines {
+		if !isIgnoredLine(fullLine) {
+			var key, value string
+			key, value, err = parseLine(fullLine)
+
+			if err != nil {
+				return
+			}
+			envMap[key] = value
+		}
+	}
+	return
+}
+
+//Unmarshal reads an env file from a string, returning a map of keys and values.
+func Unmarshal(str string) (envMap map[string]string, err error) {
+	return Parse(strings.NewReader(str))
+}
+
+// Exec loads env vars from the specified filenames (empty map falls back to default)
+// then executes the cmd specified.
+//
+// Simply hooks up os.Stdin/err/out to the command and calls Run()
+//
+// If you want more fine grained control over your command it's recommended
+// that you use `Load()` or `Read()` and the `os/exec` package yourself.
+func Exec(filenames []string, cmd string, cmdArgs []string) error {
+	Load(filenames...)
+
+	command := exec.Command(cmd, cmdArgs...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+// Write serializes the given environment and writes it to a file
+func Write(envMap map[string]string, filename string) error {
+	content, error := Marshal(envMap)
+	if error != nil {
+		return error
+	}
+	file, error := os.Create(filename)
+	if error != nil {
+		return error
+	}
+	_, err := file.WriteString(content)
+	return err
+}
+
+// Marshal outputs the given environment as a dotenv-formatted environment file.
+// Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
+func Marshal(envMap map[string]string) (string, error) {
+	lines := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		lines = append(lines, fmt.Sprintf(`%s="%s"`, k, doubleQuoteEscape(v)))
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n"), nil
+}
+
+func filenamesOrDefault(filenames []string) []string {
+	if len(filenames) == 0 {
+		return []string{".env"}
+	}
+	return filenames
+}
+
+func loadFile(filename string, overload bool) error {
+	envMap, err := readFile(filename)
+	if err != nil {
+		return err
+	}
+
+	currentEnv := map[string]bool{}
+	rawEnv := os.Environ()
+	for _, rawEnvLine := range rawEnv {
+		key := strings.Split(rawEnvLine, "=")[0]
+		currentEnv[key] = true
+	}
+
+	for key, value := range envMap {
+		if !currentEnv[key] || overload {
+			os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+func readFile(filename string) (envMap map[string]string, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	return Parse(file)
+}
+
+func parseLine(line string) (key string, value string, err error) {
+	if len(line) == 0 {
+		err = errors.New("zero length string")
+		return
+	}
+
+	// ditch the comments (but keep quoted hashes)
+	if strings.Contains(line, "#") {
+		segmentsBetweenHashes := strings.Split(line, "#")
+		quotesAreOpen := false
+		var segmentsToKeep []string
+		for _, segment := range segmentsBetweenHashes {
+			if strings.Count(segment, "\"") == 1 || strings.Count(segment, "'") == 1 {
+				if quotesAreOpen {
+					quotesAreOpen = false
+					segmentsToKeep = append(segmentsToKeep, segment)
+				} else {
+					quotesAreOpen = true
+				}
+			}
+
+			if len(segmentsToKeep) == 0 || quotesAreOpen {
+				segmentsToKeep = append(segmentsToKeep, segment)
+			}
+		}
+
+		line = strings.Join(segmentsToKeep, "#")
+	}
+
+	firstEquals := strings.Index(line, "=")
+	firstColon := strings.Index(line, ":")
+	splitString := strings.SplitN(line, "=", 2)
+	if firstColon != -1 && (firstColon < firstEquals || firstEquals == -1) {
+		//this is a yaml-style line
+		splitString = strings.SplitN(line, ":", 2)
+	}
+
+	if len(splitString) != 2 {
+		err = errors.New("Can't separate key from value")
+		return
+	}
+
+	// Parse the key
+	key = splitString[0]
+	if strings.HasPrefix(key, "export") {
+		key = strings.TrimPrefix(key, "export")
+	}
+	key = strings.Trim(key, " ")
+
+	// Parse the value
+	value = parseValue(splitString[1])
+	return
+}
+
+func parseValue(value string) string {
+
+	// trim
+	value = strings.Trim(value, " ")
+
+	// check if we've got quoted values or possible escapes
+	if len(value) > 1 {
+		first := string(value[0:1])
+		last := string(value[len(value)-1:])
+		if first == last && strings.ContainsAny(first, `"'`) {
+			// pull the quotes off the edges
+			value = value[1 : len(value)-1]
+			// handle escapes
+			escapeRegex := regexp.MustCompile(`\\.`)
+			value = escapeRegex.ReplaceAllStringFunc(value, func(match string) string {
+				c := strings.TrimPrefix(match, `\`)
+				switch c {
+				case "n":
+					return "\n"
+				case "r":
+					return "\r"
+				default:
+					return c
+				}
+			})
+		}
+	}
+
+	return value
+}
+
+func isIgnoredLine(line string) bool {
+	trimmedLine := strings.Trim(line, " \n\t")
+	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+}
+
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
+}


### PR DESCRIPTION
Avoids commiting sensible values into your repository. There's a example file config.example.yaml on how to use/implement it

The naming of the ENV variables are up to discussion, is just simple ordering the document tree.

`APP_{SECTION}_{VARIABLE}`

```bash
APP
|- DB -> var1
|- SERVER  -> var1
|- JWT  -> var1
```