### PR TITLE
Fix HTTP status codes in debug mode

### DIFF
--- a/cmd/api/server/error.go
+++ b/cmd/api/server/error.go
@@ -42,6 +42,12 @@ func (ce *customErrHandler) handler(err error, c echo.Context) {
 
 	if ce.e.Debug {
 		msg = err.Error()
+		switch err.(type) {
+		case *echo.HTTPError:
+			code = err.(*echo.HTTPError).Code
+		case validator.ValidationErrors:
+			code = http.StatusBadRequest
+		}
 	} else {
 		switch err.(type) {
 		case *echo.HTTPError:


### PR DESCRIPTION
HTTP status code in case of error if gork is configured in debug mode was always the default 500.