### PR TITLE
Remove unused struct definition [#78]

### DIFF
--- a/pkg/utl/server/error.go
+++ b/pkg/utl/server/error.go
@@ -26,10 +26,6 @@ func getVldErrorMsg(s string) string {
 	return " failed on " + s + " validation"
 }
 
-type resp struct {
-	Message string `json:"message"`
-}
-
 func (ce *customErrHandler) handler(err error, c echo.Context) {
 	var (
 		code = http.StatusInternalServerError


### PR DESCRIPTION
The package-level `resp` struct definition in `error.go` was over-ridden by an identical definition in the `handler` function (where it was used).

Closes #78