### PR TITLE
Fixed pkg/api/user/platform/pgsql

### DIFF
--- a/pkg/api/user/platform/pgsql/user.go
+++ b/pkg/api/user/platform/pgsql/user.go
@@ -29,15 +29,14 @@ func (u *User) Create(db orm.DB, usr gorsk.User) (*gorsk.User, error) {
 	var user = new(gorsk.User)
 	err := db.Model(user).Where("lower(username) = ? or lower(email) = ? and deleted_at is null",
 		strings.ToLower(usr.Username), strings.ToLower(usr.Email)).Select()
-
-	if err != nil && err != pg.ErrNoRows {
+	if (err == nil) || (err != nil && err != pg.ErrNoRows) {
 		return nil, ErrAlreadyExists
-
 	}
 
 	if err := db.Insert(&usr); err != nil {
 		return nil, err
 	}
+
 	return &usr, nil
 }
 

--- a/pkg/api/user/platform/pgsql/user_test.go
+++ b/pkg/api/user/platform/pgsql/user_test.go
@@ -1,7 +1,6 @@
 package pgsql_test
 
 import (
-	"fmt"
 	"testing"
 
 	gorsk "github.com/ribice/gorsk/pkg/utl/model"
@@ -101,7 +100,6 @@ func TestCreate(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			resp, err := udb.Create(db, tt.req)
-			fmt.Println("T", tt.name, err)
 			assert.Equal(t, tt.wantErr, err != nil)
 			if tt.wantData != nil {
 				if resp == nil {


### PR DESCRIPTION
Fixed `Create` method in `user.go`, and tests for it.
Tests coverage before:
```
PASS
coverage: 95.8% of statements
ok      github.com/ribice/gorsk/pkg/api/user/platform/pgsql
```
Tests coverage after:
```
PASS
coverage: 100.0% of statements
ok      github.com/ribice/gorsk/pkg/api/user/platform/pgsql 
```