### PR TITLE
dockertest: Added user:password as env vars to fix breaking change

### DIFF
--- a/pkg/utl/mock/postgres.go
+++ b/pkg/utl/mock/postgres.go
@@ -19,7 +19,7 @@ func NewPGContainer(t *testing.T) *dockertest.Container {
 		fatalErr(t, err)
 
 		return db.Ping()
-	})
+	}, "-e", "POSTGRES_PASSWORD=postgres", "-e", "POSTGRES_USER=postgres")
 	fatalErr(t, err)
 
 	return container

--- a/pkg/utl/postgres/pg_test.go
+++ b/pkg/utl/postgres/pg_test.go
@@ -21,7 +21,7 @@ func TestNew(t *testing.T) {
 		}
 
 		return db.Ping()
-	})
+	}, "-e", "POSTGRES_PASSWORD=postgres", "-e", "POSTGRES_USER=postgres")
 	defer container.Shutdown()
 	if err != nil {
 		t.Fatalf("could not start postgres, %s", err)


### PR DESCRIPTION
Tests were hanging due to a breaking change on docker postgres. See https://github.com/docker-library/postgres/issues/681

dockertest must now run postgresdb with extra arguments specifying environment variable `POSTGRES_PASSWORD` or `POSTGRES_HOST_AUTH_METHOD=trust`

I opted to set `POSTGRES_USER` and `POSTGRES_PASSWORD` to `postgres`, seemed like the simplest change.

I really like this starter-kit btw!